### PR TITLE
fix: update serebii paldean wooper link

### DIFF
--- a/data/pokemon/wooper-paldea.json
+++ b/data/pokemon/wooper-paldea.json
@@ -59,7 +59,7 @@
   "refs": {
     "smogon": "wooper-paldea",
     "showdown": "wooperpaldea",
-    "serebii": "Wooper",
+    "serebii": "wooper",
     "bulbapedia": "Wooper_Paldea",
     "showdownName": "Wooper-Paldea"
   }


### PR DESCRIPTION
serebii links are cAsE SeNSiTIvE so `Wooper` was leading to a 404

https://www.serebii.net/pokemon/Wooper (404s) vs https://www.serebii.net/pokemon/wooper/ (works)